### PR TITLE
Fix spec: use an active mailing recipient

### DIFF
--- a/spec/features/mailing_feature_spec.rb
+++ b/spec/features/mailing_feature_spec.rb
@@ -263,14 +263,14 @@ describe 'mailing features' do
         last_name: 'Doe',
         gender: 'M',
         language: 'en',
-        email: 'bounce@simulator.amazonses.com',
+        email: 'success@simulator.amazonses.com',
       })
     }
 
     it 'sends a single email' do
       mailing.release
       expect(mailing.send_single_email(contact.id)).to eq(
-          {"message" => "e-mail sent to bounce@simulator.amazonses.com"})
+          {"message" => "e-mail sent to success@simulator.amazonses.com"})
     end
 
     it 'handles errors correctly' do


### PR DESCRIPTION
Because handling of bounced emails automatically renders the recipient inactive, they are no longer included for delivery.
I.e. bounces@amazon... is bounced by AWS, and AWS notifies the CRM about it. The recipient is therefor deactivated for further delivery.