### PR TITLE
Fix specs: globally rename english "e-mail" to "email".

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -405,11 +405,11 @@ mailing.render_preview(contact_id)
 # }
 ```
 
-`Mailing#send_single_email` sends an e-mail to an individual contact after the mailing has already been released.
+`Mailing#send_single_email` sends an email to an individual contact after the mailing has already been released.
 
-`Mailing#send_me_a_proof_email` sends an e-mail to the authenticated API user, i.e. to the user you configured in the `Crm.configure` block.
+`Mailing#send_me_a_proof_email` sends an email to the authenticated API user, i.e. to the user you configured in the `Crm.configure` block.
 
-`Mailing#release` releases a mailing and sends e-mails to all recipients.
+`Mailing#release` releases a mailing and sends emails to all recipients.
 
 ```ruby
 recipients = Crm::Collection.create({

--- a/lib/crm/contact.rb
+++ b/lib/crm/contact.rb
@@ -68,7 +68,7 @@ module Crm
 
     # Generates a password token.
     #
-    # Use case: A project sends an e-mail to the contact. The e-mail contains a link to
+    # Use case: A project sends an email to the contact. The email contains a link to
     # the project web app. The link contains the param +?token=...+.
     # The web app retrieves and parses the token
     # and passes it to {Contact.set_password_by_token}.
@@ -81,7 +81,7 @@ module Crm
     # Sets a contact's new password by means of the token. Generate a token by calling
     # {#send_password_token_email} or {#generate_password_token}.
     #
-    # Use case: A contact clicks a link (that includes a token) in an e-mail
+    # Use case: A contact clicks a link (that includes a token) in an email
     # to get to a password change page.
     # @param new_password [String] the new password.
     # @param token [String] the given token.
@@ -102,7 +102,7 @@ module Crm
       load_attributes(Core::RestApi.instance.put("#{path}/clear_password", {}))
     end
 
-    # Sends a password token by e-mail to this contact.
+    # Sends a password token by email to this contact.
     #
     # Put a link to the project web app into the +password_request_email_body+ template.
     # The link should contain the +?token=...+ parameter, e.g.:

--- a/lib/crm/mailing.rb
+++ b/lib/crm/mailing.rb
@@ -1,7 +1,7 @@
 module Crm
-  # The purpose of an Infopark WebCRM mailing is to send an e-mail, e.g. a newsletter,
+  # The purpose of an Infopark WebCRM mailing is to send an email, e.g. a newsletter,
   # to several recipients.
-  # The e-mails will be sent to the members of the contact collection associated with the mailing
+  # The emails will be sent to the members of the contact collection associated with the mailing
   # (+mailing.collection_id+).
   #
   # Infopark WebCRM uses the {http://liquidmarkup.org/ Liquid template engine} for evaluating
@@ -19,7 +19,7 @@ module Crm
     # @!parse extend Core::Mixins::Modifiable::ClassMethods
     # @!parse extend Core::Mixins::Searchable::ClassMethods
 
-    # Renders a preview of the e-mail for the given contact.
+    # Renders a preview of the email for the given contact.
     # @example
     #   mailing.html_body
     #   # => "<h1>Welcome {{contact.first_name}} {{contact.last_name}}</h1>"
@@ -37,7 +37,7 @@ module Crm
     #   #  "html_body" => "<h1>Welcome John Doe</h1>"
     #   # }
     # @param render_for_contact_or_id [String, Contact]
-    #   the contact for which the e-mail preview is rendered.
+    #   the contact for which the email preview is rendered.
     # @return [Hash{String => String}] the values of the mailing fields evaluated
     #   in the context of the contact.
     # @api public
@@ -47,14 +47,14 @@ module Crm
       })
     end
 
-    # Sends a proof e-mail (personalized for a contact) to the current user (the API user).
+    # Sends a proof email (personalized for a contact) to the current user (the API user).
     # @example
     #   mailing.send_me_a_proof_email(contact)
     #   # => {
-    #   #   "message" => "e-mail sent to api_user@example.com"
+    #   #   "message" => "email sent to api_user@example.com"
     #   # }
     # @param render_for_contact_or_id [String, Contact]
-    #   the contact for which the proof e-mail is rendered.
+    #   the contact for which the proof email is rendered.
     # @return [Hash{String => String}] a status report.
     # @api public
     def send_me_a_proof_email(render_for_contact_or_id)
@@ -76,10 +76,10 @@ module Crm
     #
     #   mailing.send_single_email(contact)
     #   # => {
-    #   #   "message" => "e-mail sent to john.doe@example.org"
+    #   #   "message" => "email sent to john.doe@example.org"
     #   # }
     # @param recipient_contact_or_id [String, Contact]
-    #   the contact to send a single e-mail to.
+    #   the contact to send a single email to.
     # @return [Hash{String => String}] a status report.
     # @api public
     def send_single_email(recipient_contact_or_id)

--- a/lib/crm/template_set.rb
+++ b/lib/crm/template_set.rb
@@ -1,7 +1,7 @@
 module Crm
   # +TemplateSet+ represents the Infopark WebCRM template set singleton.
   # The templates of the {.singleton template set singleton} can be used to render customized text,
-  # e.g. a mailing greeting or a password request e-mail body (+password_request_email_body+).
+  # e.g. a mailing greeting or a password request email body (+password_request_email_body+).
   #
   # Infopark WebCRM uses the {http://liquidmarkup.org/ Liquid template engine} for evaluating
   # the templates.

--- a/spec/crm/mailing_spec.rb
+++ b/spec/crm/mailing_spec.rb
@@ -69,7 +69,7 @@ describe Mailing do
 
   describe '#send_me_a_proof_email' do
     let(:mailing) { Mailing.new("id" => "abc") }
-    let(:proof_output) { { "message" => "e-mail sent to apiuser.email" } }
+    let(:proof_output) { { "message" => "email sent to apiuser.email" } }
 
     before do
       expect(Core::RestApi.instance).to receive(:post).with(
@@ -107,7 +107,7 @@ describe Mailing do
 
   describe '#send_single_email' do
     let(:mailing) { Mailing.new("id" => "abc") }
-    let(:single_email_output) { { "message" => "e-mail sent to contact.email" } }
+    let(:single_email_output) { { "message" => "email sent to contact.email" } }
 
     before do
       expect(Core::RestApi.instance).to receive(:post).with(

--- a/spec/features/mailing_feature_spec.rb
+++ b/spec/features/mailing_feature_spec.rb
@@ -237,7 +237,7 @@ describe 'mailing features' do
 
     it 'sends a proof email to me (the api user)' do
       expect(mailing.send_me_a_proof_email(contact.id)).to eq(
-          {"message" => "e-mail sent to success@simulator.amazonses.com"})
+          {"message" => "email sent to success@simulator.amazonses.com"})
     end
 
     it 'handles errors correctly' do
@@ -270,7 +270,7 @@ describe 'mailing features' do
     it 'sends a single email' do
       mailing.release
       expect(mailing.send_single_email(contact.id)).to eq(
-          {"message" => "e-mail sent to success@simulator.amazonses.com"})
+          {"message" => "email sent to success@simulator.amazonses.com"})
     end
 
     it 'handles errors correctly' do


### PR DESCRIPTION
This change to the CRM localizers has been approved by andreas.