### PR TITLE
Freeze rake version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rake'
+gem 'rake', '~> 10.5.0'
 gem 'rspec', '~> 3.0'
 gem 'webmock', require: false
 gem 'autotest'


### PR DESCRIPTION
rake 11.0 renames `last_comment` to `last_description`.
Unfortunately, rspec still calls `last_comment`.