### PR TITLE
log subscriber supports array requests and responses

### DIFF
--- a/lib/crm/core/log_subscriber.rb
+++ b/lib/crm/core/log_subscriber.rb
@@ -10,7 +10,7 @@ module Crm; module Core
       info { "#{event.payload[:method].to_s.upcase} #{event.payload[:resource_path]}" }
       request_payload = event.payload[:request_payload]
       if request_payload.present?
-        debug { "  request body: #{parameter_filter.filter(request_payload)}" }
+        debug { "  request body: #{parameter_filter.filter({data: request_payload})[:data]}" }
       end
     end
 
@@ -21,7 +21,7 @@ module Crm; module Core
       }
       debug {
         response_payload = MultiJson.load(r.body)
-        "  response body: #{parameter_filter.filter(response_payload)}"
+        "  response body: #{parameter_filter.filter({data: response_payload})[:data]}"
       }
     end
 

--- a/spec/crm/core/rest_api_logging_spec.rb
+++ b/spec/crm/core/rest_api_logging_spec.rb
@@ -5,51 +5,48 @@ module Crm; module Core
 describe RestApi, 'logging' do
   let(:logger) { ActiveSupport::LogSubscriber::TestHelper::MockLogger.new }
   let(:connection_manager) { double(ConnectionManager) }
-  let!(:old_logger) { LogSubscriber.logger }
 
   before do
-    LogSubscriber.logger = logger
-
     RestApi.instance.instance_variable_set('@connection_manager', connection_manager)
-
-    allow(connection_manager).to receive(:request).and_return(
-        double(Net::HTTPResponse, code: '200', body: '{"question": "answer"}', message: 'OK'))
   end
 
-  after do
+  around do |example|
+    old_logger, LogSubscriber.logger = LogSubscriber.logger, logger
+    example.run
     LogSubscriber.logger = old_logger
   end
 
-  it "logs a short message to info" do
-    RestApi.instance.get('/foo', 'get payload')
-    expect(logger.logged(:info).length).to eq(2)
-    expect(logger.logged(:info).first).to eq('GET /foo')
-    expect(logger.logged(:info).second).to match(/200 OK 22 \(total: 0\.\dms\)/)
-  end
-
-  it "logs more details to debug" do
-    RestApi.instance.get('/foo', {'some' => 'payload'})
-    expect(logger.logged(:debug).length).to eq(2)
-    expect(logger.logged(:debug).first).to eq('request body: {"some"=>"payload"}')
-    expect(logger.logged(:debug).second).to eq('response body: {"question"=>"answer"}')
-  end
-
-  it "filters sensitive parameters (e.g. 'password')" do
+  it "logs a short message to info and details to debug", :aggregate_failures do
     allow(connection_manager).to receive(:request).and_return(
-        double(Net::HTTPResponse, code: '200', body: '{"new_password": "secret"}', message: 'OK'))
+        double(Net::HTTPResponse, code: '200', body: '[{"question": "answer"}]', message: 'OK'))
+    RestApi.instance.get('/foo', [{'some' => 'payload'}])
+    expect(logger.logged(:info)).to match([
+      'GET /foo',
+      /200 OK 24 \(total: 0\.\dms\)/,
+    ])
+    expect(logger.logged(:debug)).to eq([
+      'request body: [{"some"=>"payload"}]',
+      'response body: [{"question"=>"answer"}]',
+    ])
+  end
 
-    RestApi.instance.get('/foo', {
-      password: 'secret',
-      nested: {"new_password" => 'secret'},
-      other_datatype: [{"password2" => 'secret'}],
-    })
-    logger.logged(:info).each do |info|
-      expect(info).to_not include('secret')
-    end
-    logger.logged(:debug).each do |debug|
-      expect(debug).to include('password')
-      expect(debug).to_not include('secret')
-    end
+  it "filters sensitive parameters (e.g. 'password')", :aggregate_failures do
+    allow(connection_manager).to receive(:request).and_return(
+        double(Net::HTTPResponse, code: '200', body: '[{"new_password": "response_secret"}]', message: 'OK'))
+
+    RestApi.instance.get('/foo', [{
+      "password" => 'request_secret',
+      "nested" => {"new_password" => 'request_secret'},
+      "array" => [{"password2" => 'request_secret'}],
+    }])
+    expect(logger.logged(:info)).to match([
+      "GET /foo",
+      /200 OK 37 \(total: 0\.\dms\)/,
+    ])
+    expect(logger.logged(:debug)).to eq([
+      'request body: [{"password"=>"[FILTERED]", "nested"=>{"new_password"=>"[FILTERED]"}, "array"=>[{"password2"=>"[FILTERED]"}]}]',
+      'response body: [{"new_password"=>"[FILTERED]"}]',
+    ])
   end
 end
 


### PR DESCRIPTION
fixes issue #12

Problem: Rails 5 parameter filter crashes when the input is an array rather than a hash. But is still works when the nested values are arrays. So my solution is to wrap the request and response params in a hash with the only key `data`, e.g. `{data: ...}` before parameter filtering and then unwrap it before sending it to the logger.